### PR TITLE
Replace local_inner_macros

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,5 @@
-
 #[doc(hidden)]
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! private_define_context {
     {
         $caller:tt
@@ -11,9 +10,9 @@ macro_rules! private_define_context {
         }]
     } => {
         $crate::tt_call::tt_call! {
-            macro = [{ private_define_context }]
+            macro = [{ $crate::private_define_context }]
             rest = [{ $($body)* }]
-            ~~> private_define_context! {
+            ~~> $crate::private_define_context! {
                 $caller
                 name = [{ $name }]
             }
@@ -84,7 +83,7 @@ macro_rules! private_define_context {
         $(field = [{ $($field:tt)* }])*
         rest = [{ $field_name:ident: $t:ty [ ($($f_args:ident),*) $factory:ty ], $($rest:tt)* }]
     } => {
-        private_define_context! {
+        $crate::private_define_context! {
             $caller
             $(auto_field = [{ $($auto_field)* }])*
             auto_field = [{ $field_name, $t, $factory, ($($f_args,)*) }]
@@ -98,7 +97,7 @@ macro_rules! private_define_context {
         $(field = [{ $($field:tt)* }])*
         rest = [{ $field_name:ident: $t:ty [ ($($f_args:ident),*) $factory:ty ] }]
     } => {
-        private_define_context! {
+        $crate::private_define_context! {
             $caller
             $(auto_field = [{ $($auto_field)* }])*
             auto_field = [{ $field_name, $t, $factory, ($($f_args,)*) }]
@@ -112,7 +111,7 @@ macro_rules! private_define_context {
         $(field = [{ $($field:tt)* }])*
         rest = [{ $field_name:ident: $t:ty [ $factory:ty ], $($rest:tt)* }]
     } => {
-        private_define_context! {
+        $crate::private_define_context! {
             $caller
             $(auto_field = [{ $($auto_field)* }])*
             auto_field = [{ $field_name, $t, $factory, () }]
@@ -126,7 +125,7 @@ macro_rules! private_define_context {
         $(field = [{ $($field:tt)* }])*
         rest = [{ $field_name:ident: $t:ty [ $factory:ty ] }]
     } => {
-        private_define_context! {
+        $crate::private_define_context! {
             $caller
             $(auto_field = [{ $($auto_field)* }])*
             auto_field = [{ $field_name, $t, $factory, () }]
@@ -140,7 +139,7 @@ macro_rules! private_define_context {
         $(field = [{ $($field:tt)* }])*
         rest = [{ $field_name:ident: $t:ty, $($rest:tt)* }]
     } => {
-        private_define_context! {
+        $crate::private_define_context! {
             $caller
             $(auto_field = [{ $($auto_field)* }])*
             $(field = [{ $($field)* }])*
@@ -154,7 +153,7 @@ macro_rules! private_define_context {
         $(field = [{ $($field:tt)* }])*
         rest = [{ $field_name:ident: $t:ty }]
     } => {
-        private_define_context! {
+        $crate::private_define_context! {
             $caller
             $(auto_field = [{ $($auto_field)* }])*
             $(field = [{ $($field)* }])*
@@ -268,11 +267,11 @@ macro_rules! private_define_context {
 /// ```
 /// 
 /// 
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! define_context {
     ($($input:tt)*) => (
         $crate::tt_call::tt_call! {
-            macro = [{ private_define_context }]
+            macro = [{ $crate::private_define_context }]
             input = [{ $($input)* }]
         }
     );

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,5 +1,5 @@
 #[doc(hidden)]
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! generate_trait_def {
     {
         $caller:tt
@@ -21,7 +21,7 @@ macro_rules! generate_trait_def {
 }
 
 #[doc(hidden)]
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! generate_trait_impl {
     {
         $caller:tt
@@ -45,16 +45,16 @@ macro_rules! generate_trait_impl {
 }
 
 #[doc(hidden)]
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! private_define_interface {
     {
         $caller:tt
         input = [{ $($input:tt)* }]
     } => {
         $crate::tt_call::tt_call! {
-            macro = [{ parse_trait_def }]
+            macro = [{ $crate::parse_trait_def }]
             input = [{ $($input)* }]
-            ~~> private_define_interface! {
+            ~~> $crate::private_define_interface! {
                 $caller
             }
         }
@@ -68,11 +68,11 @@ macro_rules! private_define_interface {
         $(bound = [{ $($bound:tt)* }])*
     } => {
         $crate::tt_call::tt_call! {
-            macro = [{ join }]
+            macro = [{ $crate::join }]
             sep = [{ + }]
             $(item = [{ $($bound)* }])*
             $(item = [{ $crate::Provide<$t> }])*
-            ~~> private_define_interface! {
+            ~~> $crate::private_define_interface! {
                 $caller
                 name = [{ $name }]
                 getters = [{ $(
@@ -88,11 +88,11 @@ macro_rules! private_define_interface {
         joined = [{ $($joined:tt)* }]
     } => {
         $crate::tt_call::tt_call! {
-            macro = [{ generate_trait_def }]
+            macro = [{ $crate::generate_trait_def }]
             name = [{ $name }]
             bounds = [{ $($joined)* }]
             getters = [{ $($getters)* }]
-            ~~> private_define_interface! {
+            ~~> $crate::private_define_interface! {
                 $caller
                 name = [{ $name }]
                 getters = [{ $($getters)* }]
@@ -108,11 +108,11 @@ macro_rules! private_define_interface {
         trait_def = [{ $($trait_def:tt)* }]
     } => {
         $crate::tt_call::tt_call! {
-            macro = [{ generate_trait_impl }]
+            macro = [{ $crate::generate_trait_impl }]
             name = [{ $name }]
             bounds = [{ $($bounds)* }]
             getters = [{ $($getters)* }]
-            ~~> private_define_interface! {
+            ~~> $crate::private_define_interface! {
                 $caller
                 trait_def = [{ $($trait_def)* }]
             }
@@ -181,11 +181,11 @@ macro_rules! private_define_interface {
 /// );
 /// ```
 
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! define_interface {
     ($($input:tt)*) => (
         $crate::tt_call::tt_call! {
-            macro = [{ private_define_interface }]
+            macro = [{ $crate::private_define_interface }]
             input = [{ $($input)* }]
         }
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,9 @@
 //! 
 //! See the individual macro documentation for more details.
 
+#[doc(hidden)]
 pub extern crate tt_call;
+#[doc(hidden)]
 pub extern crate failure;
 
 mod join;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,11 +1,11 @@
 #[doc(hidden)]
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! parse_bound {
     {
         $caller:tt
         input = [{ $($input:tt)* }]
     } => {
-        parse_bound! {
+        $crate::parse_bound! {
             $caller
             rest = [{ $($input)* }]
         }
@@ -18,7 +18,7 @@ macro_rules! parse_bound {
         $crate::tt_call::tt_call! {
             macro = [{ $crate::tt_call::parse_type }]
             input = [{ $($rest)* }]
-            ~~> parse_bound! {
+            ~~> $crate::parse_bound! {
                 $caller
                 $(bound = [{ $($bound)* }])*
             }
@@ -30,7 +30,7 @@ macro_rules! parse_bound {
         type = [{ $($type:tt)* }]
         rest = [{ + $($rest:tt)* }]
     } => {
-        parse_bound! {
+        $crate::parse_bound! {
             $caller
             $(bound = [{ $($bound)* }])*
             bound = [{ $($type)* }]
@@ -53,7 +53,7 @@ macro_rules! parse_bound {
 }
 
 #[doc(hidden)]
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! parse_trait_def {
     {
         $caller:tt
@@ -70,9 +70,9 @@ macro_rules! parse_trait_def {
         input = [{ $name:ident: $($rest:tt)* }]
     } => {
         $crate::tt_call::tt_call! {
-            macro = [{ parse_bound }]
+            macro = [{ $crate::parse_bound }]
             input = [{ $($rest)* }]
-            ~~> parse_trait_def! {
+            ~~> $crate::parse_trait_def! {
                 $caller
                 name = [{ $name }]
             }


### PR DESCRIPTION
The `#[macro_export(local_inner_macros)]` attribute is intended for macros that require compatibility with rustc \<1.30. When targeting only compilers that support calling macros as `$crate::m!(...)`, that should be used instead.