### PR TITLE
Use anyhow::Error in place of Failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 tt-call = "1.0"
-failure = "0.1"
+anyhow = "1"

--- a/src/context.rs
+++ b/src/context.rs
@@ -34,7 +34,7 @@ macro_rules! private_define_context {
                 }
 
                 impl $name {
-                    fn new($($field: $t,)*) -> Result<Self, $crate::failure::Error> {
+                    fn new($($field: $t,)*) -> Result<Self, anyhow::Error> {
                         $(
                             let $auto_field = <$factory as $crate::Factory<_>>::build(($($f_args.clone(),)*))?;
                         )*
@@ -239,7 +239,6 @@ macro_rules! private_define_context {
 /// 
 /// ```
 /// use std::sync::Arc;
-/// use failure;
 /// 
 /// #[derive(Debug)]
 /// struct Foo;
@@ -249,7 +248,7 @@ macro_rules! private_define_context {
 /// struct FooFactory;
 /// impl aerosol::Factory for FooFactory {
 ///     type Object = Arc<Foo>;
-///     fn build(_: ()) -> Result<Arc<Foo>, failure::Error> { Ok(Arc::new(Foo)) }
+///     fn build(_: ()) -> Result<Arc<Foo>, anyhow::Error> { Ok(Arc::new(Foo)) }
 /// }
 /// 
 /// aerosol::define_context!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,6 @@
 //! #![recursion_limit="128"]
 //! use std::sync::Arc;
 //! use std::fmt::Debug;
-//! use failure;
 //! 
 //! // We will depend on some kind of logger
 //! trait Logger: Debug {
@@ -52,7 +51,7 @@
 //! struct StdoutLoggerFactory;
 //! impl aerosol::Factory for StdoutLoggerFactory {
 //!     type Object = Arc<Logger>;
-//!     fn build(_: ()) -> Result<Arc<Logger>, failure::Error> {
+//!     fn build(_: ()) -> Result<Arc<Logger>, anyhow::Error> {
 //!         Ok(Arc::new(StdoutLogger))
 //!     }
 //! }
@@ -87,19 +86,15 @@
 //!     }
 //! );
 //! 
-//! fn main() {
-//!     let context = AppContext::new().unwrap();
+//! let context = AppContext::new().unwrap();
 //! 
-//!     run_app(context, 4);
-//! }
+//! run_app(context, 4);
 //! ```
 //! 
 //! See the individual macro documentation for more details.
 
 #[doc(hidden)]
 pub extern crate tt_call;
-#[doc(hidden)]
-pub extern crate failure;
 
 mod join;
 mod parse;
@@ -120,7 +115,7 @@ pub trait Provide<T> {
 /// constructing implementations of dependencies.
 pub trait Factory<Args=()> {
     type Object;
-    fn build(args: Args) -> Result<Self::Object, failure::Error>;
+    fn build(args: Args) -> Result<Self::Object, anyhow::Error>;
 }
 
 /// Allows cloning a context whilst replacing one dependency

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 extern crate aerosol;
 #[macro_use]
 extern crate tt_call;
-extern crate failure;
 
 #[macro_export]
 macro_rules! tt_debug2 {
@@ -40,7 +39,7 @@ struct Bar;
 
 impl aerosol::Factory<(Bar,)> for FooFactory {
     type Object = Foo;
-    fn build(_: (Bar,)) -> Result<Foo, failure::Error> { Ok(Foo) }
+    fn build(_: (Bar,)) -> Result<Foo, anyhow::Error> { Ok(Foo) }
 }
 
 aerosol::define_context!(


### PR DESCRIPTION
Since Failure is now deprecated, and Rust's own std::error::Error trait
doesn't preserve a backtrace on Stable, if we want to move to a
supported library the most obvious successor is Anyhow.