### PR TITLE
Add try_insert method to `Aero`

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -72,10 +72,19 @@ impl<R: ResourceList> Aero<R> {
     /// Directly insert a resource into the collection. Panics if a resource of the
     /// same type already exists.
     pub fn insert<T: Resource>(&self, value: T) {
+        if self.try_insert(value).is_err() {
+            duplicate_resource::<T>();
+        }
+    }
+
+    /// Directly insert a resource into the collection. Returns nothing if the resource
+    /// was inserted successfully and the provided value if another resource of the same type already exists.
+    pub fn try_insert<T: Resource>(&self, value: T) -> Result<(), T> {
         match self.inner.write().items.entry() {
-            Entry::Occupied(_) => duplicate_resource::<T>(),
+            Entry::Occupied(_) => Err(value),
             Entry::Vacant(vac) => {
                 vac.insert(Slot::Filled(value));
+                Ok(())
             }
         }
     }


### PR DESCRIPTION
Just started using this crate and it's been working perfectly for my needs so far! One thing which I would like to have is the ability to recover gracefully from failed insertions rather than panicking.

I've implemented that here with a `try_insert` method, which returns an indicator of whether the insertion was successful or not.