### PR TITLE
Unpin time dependency and bump MSRV to 1.84

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -66,14 +66,14 @@ jobs:
           args: --all-features
 
   test_minimum:
-    name: Test (1.78.0)
+    name: Test (1.84.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.78.0
+          toolchain: 1.84.0
           override: true
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -76,6 +76,12 @@ jobs:
           toolchain: 1.84.0
           override: true
       - uses: actions-rs/cargo@v1
+        # Opt into MSRV-aware dependency resolution so Cargo picks dependency
+        # versions compatible with our declared rust-version instead of the
+        # newest available. This mirrors what a downstream user on our MSRV
+        # would enable via `resolver.incompatible-rust-versions = "fallback"`.
+        env:
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
         with:
           command: test
           args: --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aerosol"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Diggory Blake <diggsey@googlemail.com>"]
 edition = "2018"
 description = "Simple dependency injection for Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 description = "Simple dependency injection for Rust"
 repository = "https://github.com/Diggsey/aerosol"
 license = "MIT OR Apache-2.0"
-rust-version = "1.78.0"
+rust-version = "1.84.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,11 @@ frunk = { version = "0.4.2", default-features = false }
 aide = { version = "0.15", optional = true, default-features = false, features = [
     "axum",
 ] }
-time = "=0.3.41" # time 0.3.42 and up require rustc 1.81.0
+
+# time 0.3.42 and up require rustc 1.81.0. We don't need to pin it because
+# Cargo's v3 resolver will automatically take the MSRV of the root crate
+# into account when resolving dependencies.
+time = "0.3.41"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "time", "rt"] }


### PR DESCRIPTION
## Summary
- Unpins the `time` dependency (from `=0.3.41` to `0.3.41`).
- Bumps the crate's MSRV from 1.78 to 1.84.
- Bumps the crate patch version to 1.3.1.

## Why unpin `time`?
`time` 0.3.42+ requires rustc 1.81.0, which is why it was previously pinned to an exact version. Cargo's v3 resolver already takes the root crate's `rust-version` (MSRV) into account when resolving dependencies, so a too-new `time` won't be selected for users on an older toolchain — the exact pin is unnecessary.

## Why bump MSRV to 1.84?
MSRV-aware dependency resolution is only fully usable once users can opt into it via `resolver.incompatible-rust-versions = "fallback"`, and that config key requires **Rust 1.84**. With an MSRV below 1.84, users can't enable the fallback behavior that makes unpinning `time` safe for them. Raising our MSRV to 1.84 ensures the resolver mechanism this PR relies on is actually available to consumers of the crate.

Note: this raises the effective MSRV for all users of the crate.